### PR TITLE
Fix the teardown code to do a full reset.

### DIFF
--- a/examples/stm32/f4/stm32f429i-discovery/dac/Makefile
+++ b/examples/stm32/f4/stm32f429i-discovery/dac/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = dac
+
+LDSCRIPT = ../stm32f429i-discovery.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/stm32f429i-discovery/dac/README.md
+++ b/examples/stm32/f4/stm32f429i-discovery/dac/README.md
@@ -1,0 +1,19 @@
+# README
+
+An exploration of the STM32F4 DAC
+
+This provides a collection of all the wave generating capabilities of
+the DAC that don't use dual modes. Press the user button to switch
+modes. The mode is output to TX1 at 115200 baud when you switch.
+
+Example waves include two sawtooth waves, a square wave, white noise,
+a triangle and a sine wave with added noise.
+
+Some terms used in the descriptions:
+
+- *Software-loaded* - The value is loaded to the DAC by the CPU.
+- *Software-triggered* - The next value of a generated wave is 
+  triggered by the CPU setting a control bit.
+- *Timer-triggered* - The next value of a generated wave is triggered
+  by a timer.
+- *DMA transferred* - Values are loaded from memory via DMA.

--- a/examples/stm32/f4/stm32f429i-discovery/dac/dac.c
+++ b/examples/stm32/f4/stm32f429i-discovery/dac/dac.c
@@ -1,0 +1,463 @@
+/*
+ * Some basic STM32 DAC examples.
+ *
+ * This demo runs through a series of DAC examples. Pressing the User button
+ * switches to the next example, cycling back to the start afte the last one.
+ *
+ * Information about the demo is spit out on USART1 when it starts.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/dac.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/timer.h>
+#include <libopencm3/stm32/dma.h>
+
+static void
+clock_setup(void) {
+     /* Base board frequency, set to 168Mhz */
+     rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+}
+
+/* Turn off anything that we don't want on for everything */
+static void
+dac_teardown(void) {
+     dma_stream_reset(DMA1, DMA_STREAM6);
+
+     timer_reset(TIM6);
+
+     dac_disable(CHANNEL_2);
+     dac_trigger_disable(CHANNEL_2);
+     dac_dma_disable(CHANNEL_2);
+     dac_disable_waveform_generation(CHANNEL_2);
+}
+
+/* Setup shared by all the DAC exapmles. */
+static void
+dac_setup(void) {
+     rcc_periph_clock_enable(RCC_GPIOA);
+     rcc_periph_clock_enable(RCC_DAC);
+     rcc_periph_clock_enable(RCC_TIM6);
+     rcc_periph_clock_enable(RCC_DMA1);
+
+     gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO5);
+
+     /* And make sure we're in a known state */
+     dac_teardown();
+}
+     
+
+/*
+ * The ramp up/down code writes the values itself, so we just enable the DAC.
+ *
+ * Frequency approx 1500Hz.
+ */
+
+static void
+dac_ramp_setup(void) {
+     dac_enable(CHANNEL_2);
+}
+     
+static void
+dac_rampdown(void) {
+     for (int16_t i = 4095; i > 0; i -= 1) {
+          dac_load_data_buffer_single(i, RIGHT12, CHANNEL_2);
+     }
+}
+
+static void
+dac_rampup(void) {
+     for (uint16_t i = 0; i < 4096; i += 1) {
+          dac_load_data_buffer_single(i, RIGHT12, CHANNEL_2);
+     }
+}
+
+/*
+ * Set up for a software triggered noise wave form.
+ *
+ * Note that this is actually added to the output waveform. Since we
+ * aren't changing the intput digital value, it's always zero, so we
+ * just get noise.
+ *
+ * Frequency is noise, but the value changes in microseconds.
+ */
+static void
+dac_noise_setup(void) {
+     dac_set_waveform_generation(DAC_CR_WAVE2_NOISE);
+     /* 10 bit - or 1024 - maximum amplitude value of about .25 VREF */
+     dac_set_waveform_characteristics(DAC_CR_MAMP2_10);
+     dac_set_trigger_source(DAC_CR_TSEL2_SW);
+     dac_trigger_enable(CHANNEL_2);
+     dac_enable(CHANNEL_2);
+}     
+
+static void
+dac_noise(void) {
+     /* With 12 bits, it's up from 0 to 4095, then down from 4096 to 8191 */
+     for (uint16_t i = 0; i < 8192; i += 1)  {
+          dac_software_trigger(CHANNEL_2);
+     }
+ }
+
+/*
+ * Timer-triggered triangle.
+ *
+ * The DAC setup is similar to the above, except we use _TRI wave
+ * instead of an _NOISE wave. And the trigger source is _T6 instead of
+ * _SW. This means that, instead of calling dac_software_trigger to
+ * write to the appropriate register to trigger DAC output, we set the
+ * timer up, and it will trigger the output at a regular interval for
+ * us. Which means we don't need a "run" method.
+ *
+ * Frequency: about 1.3 Khz, but see the comments in the function for
+ * details.
+ */
+static void
+dac_triangle_setup(void) {
+    /* Set up and start the dac wave generation */
+     dac_set_waveform_generation(DAC_CR_WAVE2_TRI);
+     dac_set_waveform_characteristics(DAC_CR_MAMP2_12);
+     dac_buffer_enable(CHANNEL_2);
+     dac_trigger_enable(CHANNEL_2);
+     dac_set_trigger_source(DAC_CR_TSEL2_T6);
+     dac_enable(CHANNEL_2);
+
+     /*
+      * Set up and start the timer.
+      *
+      * The timer counts up by 1 for every prescaler + 1 clock ticks.
+      * The clock ticks at 84Mhz (it's 1/2 the 168MHz clock set in
+      * clock_setup).The prescaler is 16 bits, so ranges from 0 to
+      * 65535. However, the DAC takes 3 clock cycles to update when
+      * given a new value, so you can't use a clock faster 4 clocks.
+      * So we set the prescaler to 3.
+      *
+      * If you need a really high frequency waveform, the update happens in
+      * 1 clock if the CPU does the work with either a software trigger for
+      * generated waves, or storing the value directly as with the ramp
+      * examples. But the DAC response time is liable to be more of a limit;
+      * see the square wave example for more.
+      */
+     timer_set_prescaler(TIM6, 3);
+
+     /*
+      * The timer generates a signal when it counts from 0 to period.
+      * This is another 16 bit value, and must be > 1.
+      *   (84 * 1000) / ((prescaler + 1) * (period + 1) * (length of waveform))
+      * = 84000 / (4 * 2 * 8192) = 1.28KHz
+      */
+     timer_set_period(TIM6, 1);
+
+     /* Now turn it and it's interrupts on */
+     timer_continuous_mode(TIM6);
+     timer_enable_update_event(TIM6);
+     timer_set_master_mode(TIM6, TIM_CR2_MMS_UPDATE);
+     timer_enable_counter(TIM6);
+}
+
+
+/*
+ * DMA square wave.
+ *
+ * Probably the most useful mode. You can feed it an arbitrary wave (but
+ * we're going to use a square wave) without the amplitude/frequency
+ * interactions of the generated triangle wave, but instead of the work
+ * being done by the CPU, we're going set up an array holding the wave
+ * and let the DMA hardware feed the dac.
+ *
+ * Frequency: 20Khz. This is about the fastest full amplitude square wave
+ * that can be reasonably generated with this hardware, as the DAC can't
+ * respond much faster than that. 40Kz
+ *
+ */
+static uint8_t
+dac_square_waveform[] = {
+     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+     
+static void
+dac_square_setup(void) {
+     /*
+      * Set up the DMA channel
+      *
+      * It must be disabled for any of this to work. The _EN bit will be on
+      * until any ongoing work is finished after we disable it, so we wait on that
+      * as well.
+      */
+     dma_disable_stream(DMA1, DMA_STREAM6);
+     while (DMA_SCR(DMA1, DMA_STREAM6) & DMA_SxCR_EN)
+          ;
+
+     /* DAC 2 8-bit register is the periperhal, the waveform is the memory */
+     dma_set_peripheral_address(DMA1, DMA_STREAM6, (uint32_t) &DAC_DHR8R2);
+     dma_set_memory_address(DMA1, DMA_STREAM6, (uint32_t) dac_square_waveform);
+     dma_set_number_of_data(DMA1, DMA_STREAM6, sizeof(dac_square_waveform));
+
+     /* DAC channel 2 uses DMA controller 1 channel 7 stream 6. Medium priority */
+     dma_channel_select(DMA1, DMA_STREAM6, DMA_SxCR_CHSEL_7);
+     dma_set_priority(DMA1, DMA_STREAM6, DMA_SxCR_PL_MEDIUM);
+
+     /*
+      * Transfer data from the waveform 8 bits at a time, going to the next
+      * item, starting over when we reach the end.
+      */
+     dma_set_transfer_mode(DMA1, DMA_STREAM6, DMA_SxCR_DIR_MEM_TO_PERIPHERAL);
+     dma_enable_memory_increment_mode(DMA1, DMA_STREAM6);
+     dma_set_memory_size(DMA1, DMA_STREAM6, DMA_SxCR_MSIZE_8BIT);
+     dma_set_peripheral_size(DMA1, DMA_STREAM6, DMA_SxCR_PSIZE_8BIT);
+     dma_enable_circular_mode(DMA1, DMA_STREAM6);
+
+     /* Now enable it all */
+     dma_enable_stream(DMA1, DMA_STREAM6);
+
+     /*
+      * Set up and and start the dac.
+      *
+      * Same as for the triangle generation, except we enable dma so a
+      * trigger event causes a DMA transfer instead of wave generation.
+      */
+     dac_buffer_enable(CHANNEL_2);
+     dac_trigger_enable(CHANNEL_2);
+     dac_dma_enable(CHANNEL_2);
+     dac_set_trigger_source(DAC_CR_TSEL2_T6);
+     dac_enable(CHANNEL_2);
+
+     /*
+      * Set up and start the timer that makes it all go.
+      *
+      * The timer is doing the same thing as in the triangle example, so the
+      * setup is the same - except for the frequency. This uses a prescaler of
+      * 0 instead of 3, as we aren't pushing that boundary in the timer.
+      * The frequency is 84000 / (1 * 210 * 20) = 20 KHz.
+      */
+     timer_set_prescaler(TIM6, 0);
+     timer_set_period(TIM6, 209);
+     timer_continuous_mode(TIM6);
+     timer_enable_update_event(TIM6);
+     timer_set_master_mode(TIM6, TIM_CR2_MMS_UPDATE);
+     timer_enable_counter(TIM6);
+}
+
+/*
+ * A noisy sine wave
+ *
+ * Finally, to tie a bow on it, we're going to combine the last three examples
+ * to create a sine wave with some added high-frequency noise.
+ *
+ * Frequency: 10KHz
+ */
+uint8_t dac_sine_waveform[] = {
+     67, 67, 68, 68, 69, 69, 69, 70, 70, 71, 71, 71, 72, 72, 73,
+     73, 73, 74, 74, 75, 75, 75, 76, 76, 77, 77, 77, 78, 78, 79,
+     79, 79, 80, 80, 81, 81, 81, 82, 82, 82, 83, 83, 84, 84, 84,
+     85, 85, 86, 86, 86, 87, 87, 88, 88, 88, 89, 89, 89, 90, 90,
+     91, 91, 91, 92, 92, 92, 93, 93, 94, 94, 94, 95, 95, 95, 96,
+     96, 96, 97, 97, 98, 98, 98, 99, 99, 99,100,100,100,101,101,
+     101,102,102,102,103,103,103,104,104,104,105,105,105,106,106,
+     106,107,107,107,108,108,108,109,109,109,110,110,110,110,111,
+     111,111,112,112,112,113,113,113,113,114,114,114,115,115,115,
+     115,116,116,116,117,117,117,117,118,118,118,118,119,119,119,
+     119,120,120,120,120,121,121,121,121,122,122,122,122,122,123,
+     123,123,123,124,124,124,124,124,125,125,125,125,125,126,126,
+     126,126,126,127,127,127,127,127,127,128,128,128,128,128,128,
+     129,129,129,129,129,129,130,130,130,130,130,130,130,130,131,
+     131,131,131,131,131,131,131,132,132,132,132,132,132,132,132,
+     132,132,132,133,133,133,133,133,133,133,133,133,133,133,133,
+     133,133,133,134,134,134,134,134,134,134,134,134,134,134,134,
+     134,134,134,134,134,134,134,134,134,134,134,134,134,134,134,
+     134,134,134,134,134,134,134,134,134,134,134,134,134,133,133,
+     133,133,133,133,133,133,133,133,133,133,133,133,133,132,132,
+     132,132,132,132,132,132,132,132,132,131,131,131,131,131,131,
+     131,131,130,130,130,130,130,130,130,130,129,129,129,129,129,
+     129,128,128,128,128,128,128,127,127,127,127,127,127,126,126,
+     126,126,126,125,125,125,125,125,124,124,124,124,124,123,123,
+     123,123,122,122,122,122,122,121,121,121,121,120,120,120,120,
+     119,119,119,119,118,118,118,118,117,117,117,117,116,116,116,
+     115,115,115,115,114,114,114,113,113,113,113,112,112,112,111,
+     111,111,110,110,110,110,109,109,109,108,108,108,107,107,107,
+     106,106,106,105,105,105,104,104,104,103,103,103,102,102,102,
+     101,101,101,100,100,100, 99, 99, 99, 98, 98, 98, 97, 97, 96,
+      96, 96, 95, 95, 95, 94, 94, 94, 93, 93, 92, 92, 92, 91, 91,
+      91, 90, 90, 89, 89, 89, 88, 88, 88, 87, 87, 86, 86, 86, 85,
+      85, 84, 84, 84, 83, 83, 82, 82, 82, 81, 81, 81, 80, 80, 79,
+      79, 79, 78, 78, 77, 77, 77, 76, 76, 75, 75, 75, 74, 74, 73,
+      73, 73, 72, 72, 71, 71, 71, 70, 70, 69, 69, 69, 68, 68, 67,
+      67, 67, 66, 66, 65, 65, 65, 64, 64, 63, 63, 63, 62, 62, 61,
+      61, 61, 60, 60, 59, 59, 59, 58, 58, 57, 57, 57, 56, 56, 55,
+      55, 55, 54, 54, 53, 53, 53, 52, 52, 52, 51, 51, 50, 50, 50,
+      49, 49, 48, 48, 48, 47, 47, 46, 46, 46, 45, 45, 45, 44, 44,
+      43, 43, 43, 42, 42, 42, 41, 41, 40, 40, 40, 39, 39, 39, 38,
+      38, 38, 37, 37, 36, 36, 36, 35, 35, 35, 34, 34, 34, 33, 33,
+      33, 32, 32, 32, 31, 31, 31, 30, 30, 30, 29, 29, 29, 28, 28,
+      28, 27, 27, 27, 26, 26, 26, 25, 25, 25, 24, 24, 24, 24, 23,
+      23, 23, 22, 22, 22, 21, 21, 21, 21, 20, 20, 20, 19, 19, 19,
+      19, 18, 18, 18, 17, 17, 17, 17, 16, 16, 16, 16, 15, 15, 15,
+      15, 14, 14, 14, 14, 13, 13, 13, 13, 12, 12, 12, 12, 12, 11,
+      11, 11, 11, 10, 10, 10, 10, 10,  9,  9,  9,  9,  9,  8,  8,
+       8,  8,  8,  7,  7,  7,  7,  7,  7,  6,  6,  6,  6,  6,  6,
+       5,  5,  5,  5,  5,  5,  4,  4,  4,  4,  4,  4,  4,  4,  3,
+       3,  3,  3,  3,  3,  3,  3,  2,  2,  2,  2,  2,  2,  2,  2,
+       2,  2,  2,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+       1,  1,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+       0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+       0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,
+       1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  2,
+       2,  2,  2,  2,  2,  2,  2,  2,  2,  3,  3,  3,  3,  3,  3,
+       3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  5,  5,  5,  5,  5,
+       5,  6,  6,  6,  6,  6,  6,  7,  7,  7,  7,  7,  7,  8,  8,
+       8,  8,  8,  9,  9,  9,  9,  9, 10, 10, 10, 10, 10, 11, 11,
+      11, 11, 12, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14,
+      15, 15, 15, 15, 16, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18,
+      19, 19, 19, 19, 20, 20, 20, 21, 21, 21, 21, 22, 22, 22, 23,
+      23, 23, 24, 24, 24, 24, 25, 25, 25, 26, 26, 26, 27, 27, 27,
+      28, 28, 28, 29, 29, 29, 30, 30, 30, 31, 31, 31, 32, 32, 32,
+      33, 33, 33, 34, 34, 34, 35, 35, 35, 36, 36, 36, 37, 37, 38,
+      38, 38, 39, 39, 39, 40, 40, 40, 41, 41, 42, 42, 42, 43, 43,
+      43, 44, 44, 45, 45, 45, 46, 46, 46, 47, 47, 48, 48, 48, 49,
+      49, 50, 50, 50, 51, 51, 52, 52, 52, 53, 53, 53, 54, 54, 55,
+      55, 55, 56, 56, 57, 57, 57, 58, 58, 59, 59, 59, 60, 60, 61,
+      61, 61, 62, 62, 63, 63, 63, 64, 64, 65, 65, 65, 66, 66, 67,
+};
+
+static void
+dac_sine_setup(void) {
+     /* Set up the DMA channel. Identical to the square wave setup */
+     dma_disable_stream(DMA1, DMA_STREAM6);
+     while (DMA_SCR(DMA1, DMA_STREAM6) & DMA_SxCR_EN)
+          ;
+     dma_set_peripheral_address(DMA1, DMA_STREAM6, (uint32_t) &DAC_DHR8R2);
+     dma_set_memory_address(DMA1, DMA_STREAM6, (uint32_t) dac_sine_waveform);
+     dma_set_number_of_data(DMA1, DMA_STREAM6, sizeof(dac_sine_waveform));
+     dma_channel_select(DMA1, DMA_STREAM6, DMA_SxCR_CHSEL_7);
+     dma_set_priority(DMA1, DMA_STREAM6, DMA_SxCR_PL_MEDIUM);
+     dma_set_transfer_mode(DMA1, DMA_STREAM6, DMA_SxCR_DIR_MEM_TO_PERIPHERAL);
+     dma_enable_memory_increment_mode(DMA1, DMA_STREAM6);
+     dma_set_memory_size(DMA1, DMA_STREAM6, DMA_SxCR_MSIZE_8BIT);
+     dma_set_peripheral_size(DMA1, DMA_STREAM6, DMA_SxCR_PSIZE_8BIT);
+     dma_enable_circular_mode(DMA1, DMA_STREAM6);
+     dma_enable_stream(DMA1, DMA_STREAM6);
+
+     /* Set up and and start the dac, but add noise generation */
+     dac_set_waveform_generation(DAC_CR_WAVE2_NOISE);
+     dac_set_waveform_characteristics(DAC_CR_MAMP2_11);
+     dac_buffer_enable(CHANNEL_2);
+     dac_trigger_enable(CHANNEL_2);
+     dac_dma_enable(CHANNEL_2);
+     dac_set_trigger_source(DAC_CR_TSEL2_T6);
+     dac_enable(CHANNEL_2);
+
+     /* Set up and start the timer that makes it all go. */
+     timer_set_prescaler(TIM6, 0);
+     timer_set_period(TIM6, 7);
+     timer_continuous_mode(TIM6);
+     timer_enable_update_event(TIM6);
+     timer_set_master_mode(TIM6, TIM_CR2_MMS_UPDATE);
+     timer_enable_counter(TIM6);
+} 
+
+typedef struct {
+     void (*setup)(void);
+     void (*run)(void);
+     char *name;
+} example;
+
+example examples[] = {
+     {dac_ramp_setup, dac_rampup, "Software-loaded sawtooth ramp up"},
+     {dac_noise_setup, dac_noise, "Software-triggered generated noise"},
+     {dac_triangle_setup, (void (*)()) 0, "Timer-triggered generated triangle"},
+     {dac_square_setup, (void (*)()) 0, "DMA transferred square wave"},
+     {dac_sine_setup, (void (*)()) 0, "DMA transferred sine wave with noise"}, 
+     {dac_ramp_setup, dac_rampdown, "Software-loaded sawtooth ramp down"},
+};
+     
+
+/*
+ * A bunch of utility routines for the usart & button.
+ * 
+ * The hardware should be isolated into these routines. Want to use a
+ * different usart/button/whatever? Just make the usart/button/whatever_
+ * routines use that hardware. Everything else should use those routines.
+ */
+static void
+button_setup(void) {
+     rcc_periph_clock_enable(RCC_GPIOA);
+     gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO0);
+}     
+
+static int button_down(void) {
+     return GPIOA_IDR & 1 ;
+}
+
+
+#define CONSOLE USART1
+static void
+usart_setup(void) {
+     	/* Enable clocks for USART2. */
+	rcc_periph_clock_enable(RCC_USART1);
+
+	/* Setup GPIO pins for USART1 transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO9);
+
+	usart_set_baudrate(CONSOLE, 115200);
+	usart_set_databits(CONSOLE, 8);
+	usart_set_stopbits(CONSOLE, USART_STOPBITS_1);
+	usart_set_mode(CONSOLE, USART_MODE_TX);
+	usart_set_parity(CONSOLE, USART_PARITY_NONE);
+	usart_set_flow_control(USART1, USART_FLOWCONTROL_NONE);
+
+	/* Finally enable the USART. */
+	usart_enable(USART1);
+}
+
+static void
+usart_putc(char c) {
+     uint32_t	reg;
+     do {
+          reg = USART_SR(CONSOLE);
+     } while ((reg & USART_SR_TXE) == 0);
+     USART_DR(CONSOLE) = (uint16_t) c & 0xff;
+}
+
+static void
+usart_putline(char *s) {
+     while (*s != 0) {
+          usart_putc(*s);
+          /* Add in a carraige return, after sending line feed */
+          if (*s == '\n') {
+               usart_putc('\r');
+          }
+          s += 1;
+     }
+     usart_putc('\n');
+     usart_putc('\r');
+}
+
+
+int
+main(void) {
+     static int button_pressed = 0;
+     clock_setup();
+     button_setup();
+     usart_setup();
+     dac_setup();
+     
+     unsigned current = 0;
+     examples[current].setup();
+     usart_putline(examples[current].name);
+     for (;;) {
+          if (examples[current].run)
+               examples[current].run();
+          if (!button_down()) {
+               button_pressed = 0;
+          } else if (!button_pressed) {
+               button_pressed = 1;
+               current = (current + 1) % (sizeof(examples) / sizeof(example));
+               dac_teardown();
+               examples[current].setup();
+               usart_putline(examples[current].name);
+          }
+     }
+}

--- a/examples/stm32/f4/stm32f429i-discovery/dac/dac.c
+++ b/examples/stm32/f4/stm32f429i-discovery/dac/dac.c
@@ -23,14 +23,9 @@ clock_setup(void) {
 /* Turn off anything that we don't want on for everything */
 static void
 dac_teardown(void) {
-     dma_stream_reset(DMA1, DMA_STREAM6);
-
-     timer_reset(TIM6);
-
-     dac_disable(CHANNEL_2);
-     dac_trigger_disable(CHANNEL_2);
-     dac_dma_disable(CHANNEL_2);
-     dac_disable_waveform_generation(CHANNEL_2);
+     rcc_periph_reset_pulse(RST_DMA1);
+     rcc_periph_reset_pulse(RST_TIM6);
+     rcc_periph_reset_pulse(RST_DAC);
 }
 
 /* Setup shared by all the DAC exapmles. */


### PR DESCRIPTION
This fixes the teardown code in the dac example so it properly resets the peripherals between examples, so this works now.
